### PR TITLE
Criar o banco inicial

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Com base no universo criado por HP Lovecraft, Call of Cthulhu busca contar a his
     ````
 **Obs**: caso o passo 3 não funcione, troque "20251-callofcthulhu-db-1", pelo nome criado pelo seu docker. Para isso, rode ``docker ps -a``, pegue o nome do container que está rodando e troque pelo comando do passo 3.
 
+---
+
 ### Como rodar o banco com o DBBeaver
 O DBBeaver é uma plataforma gratuíta para trabalhar com bancos de dados, com suporte para múltiplos SQL databases, assim como o PostgreSQL.
 1. Acesse o site e [baixe o DBBeaver](https://dbeaver.io/download/)
@@ -50,3 +52,52 @@ O DBBeaver é uma plataforma gratuíta para trabalhar com bancos de dados, com s
     ![passo2](image-2.png)
     1. Preencha as informações do banco, são as mesmas do arquivo ``docker-compose.yml``
     ![passo3](image-1.png)
+1. Clique em **Test Connection** para garantir que está funcionando e depois em **Finish**
+1. Agora você poderá:
+    - Visualizar os schemas (`game`, `player`, `public`)
+    - Navegar entre as tabelas, views, etc.
+    - Executar scripts SQL diretamente pelo editor do DBeaver
+
+---------------
+
+### Como rodar scripts SQL no banco
+
+Depois que o banco está rodando via Docker, você pode aplicar scripts SQL necessários com este comando:
+```bash
+docker exec -i <nome-do-container> psql -U postgres -d call_of_chtulhu -f <caminho-do-arquivo.sql>
+```
+
+Por exemplo, para rodar o script de criação do banco (createdb.sql):
+```bash
+docker exec -i 20251-callofcthulhu-db-1 psql -U postgres -d call_of_chtulhu -f ./db/createdb.sql
+```
+
+Se der erro de nome do container, use:
+```bash
+docker ps -a
+```
+
+# Comandos básicos no psql (dentro do container)
+Para entrar no terminal interativo do banco:
+
+```bash
+docker exec -it 20251-callofcthulhu-db-1 psql -U postgres -d call_of_chtulhu
+```
+Dentro do psql, alguns comandos úteis:
+
+| Comando                 | O que faz                     |
+| ----------------------- | ----------------------------- |
+| `\l`                    | Lista os bancos de dados      |
+| `\c nome_do_banco`      | Conecta em outro banco        |
+| `\dt`                   | Lista tabelas no schema atual |
+| `\d nome_tabela`        | Mostra detalhes da tabela     |
+| `\dn`                   | Lista schemas                 |
+| `\du`                   | Lista roles                   |
+| `\q`                    | Sai do psql                   |
+| `SELECT * FROM tabela;` | Consulta dados da tabela      |
+
+# Restaurar backups usando Docker
+Se quiser restaurar um backup .dump usando pg_restore:
+```bash
+docker exec -i 20251-callofcthulhu-db-1 pg_restore -U postgres -d call_of_chtulhu < backup.dump
+```

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,15 @@
+-- Cria roles
+CREATE ROLE admin_role WITH LOGIN PASSWORD 'admin123' SUPERUSER CREATEDB CREATEROLE NOINHERIT;
+CREATE ROLE player_role WITH LOGIN PASSWORD 'player123' NOINHERIT;
+
+-- Cria schemas
+CREATE SCHEMA IF NOT EXISTS game AUTHORIZATION admin_role;
+CREATE SCHEMA IF NOT EXISTS player AUTHORIZATION admin_role;
+
+-- Ajusta permissões
+GRANT ALL ON SCHEMA game TO admin_role;
+GRANT ALL ON SCHEMA player TO admin_role;
+
+GRANT USAGE ON SCHEMA player TO player_role;
+-- As tabelas do schema player ainda não existem, então para garantir permissões futuras:
+ALTER DEFAULT PRIVILEGES IN SCHEMA player GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO player_role;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=call_of_chtulhu
+      - POSTGRES_DB=call_of_cthulhu
     volumes:
       - pg-data:/var/lib/postgresql/data
+      - ./db:/docker-entrypoint-initdb.d  # pasta local com scripts SQL
 volumes:
   pg-data:


### PR DESCRIPTION
## 📝 Descrição

Adiciona ao README.md as instruções completas para rodar o banco de dados usando Docker e também para conectar ao banco usando o DBeaver. O objetivo é facilitar o setup local do banco para todos os integrantes do grupo, garantindo que todos possam rodar scripts e visualizar os dados facilmente.

## 📌 Tarefa Relacionada

Closes #6

## 🔍 Alterações Realizadas

- Adição da seção **Como rodar o banco com o Docker** no README
- Adição da seção **Como rodar o banco com o DBeaver** no README
- Inclusão de exemplos de comandos úteis no psql
- Inclusão de instruções para rodar scripts SQL via terminal e DBeaver

## ✅ Checklist

- [x] O código foi testado localmente (testei os comandos no Docker e no DBeaver)
- [x] As alterações estão de acordo com o padrão de codificação do projeto (estrutura clara no README)
- [x] Não quebrei nenhuma funcionalidade existente

## 🧪 Como Testar

1. Rodar `docker compose up -d`
2. Verificar se o container do banco sobe corretamente (`docker ps`)
3. Testar conexão no DBeaver usando as credenciais e porta configuradas
4. Executar um script `.sql` pelo terminal ou pelo editor do DBeaver para validar

## ⚠️ Notas Adicionais

- Se alguém encontrar erro de conexão no DBeaver, verificar se a porta configurada no `docker-compose.yml` (5431) está correta no editor.
- Adicionei exemplos claros no README para evitar dúvidas — caso queiram mais imagens ou gifs ilustrativos, posso complementar depois.
