### PR TITLE
Respaw de monstros e itens

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -352,7 +352,6 @@ class DataBase:
         query = "SELECT * FROM public.sp_vasculhar_local(%s);"
         return self._execute_query(query, (local_id,), fetch_all=True)
 
-    # Novo método para chamar a stored procedure sp_adicionar_item_ao_inventario
     def add_item_to_inventory(self, id_jogador: int, id_instancia_item: int):
         """
         Chama a stored procedure sp_adicionar_item_ao_inventario para adicionar
@@ -360,7 +359,6 @@ class DataBase:
         """
         query = "SELECT public.sp_adicionar_item_ao_inventario(%s, %s);"
         result = self._execute_query(query, (id_jogador, id_instancia_item), fetch_one=True)
-        # A stored procedure retorna TRUE ou FALSE, entao verificamos o valor booleano
         return result and result['sp_adicionar_item_ao_inventario']
     
 

--- a/app/database.py
+++ b/app/database.py
@@ -343,6 +343,45 @@ class DataBase:
             'status': local_data['status'], 
             'saidas': full_saidas
         }
+    
+    def get_items_in_location(self, local_id: int):
+        """
+        Chama a stored procedure sp_vasculhar_local para buscar e retornar
+        todos os itens presentes em um local específico.
+        """
+        query = "SELECT * FROM public.sp_vasculhar_local(%s);"
+        return self._execute_query(query, (local_id,), fetch_all=True)
+
+    # Novo método para chamar a stored procedure sp_adicionar_item_ao_inventario
+    def add_item_to_inventory(self, id_jogador: int, id_instancia_item: int):
+        """
+        Chama a stored procedure sp_adicionar_item_ao_inventario para adicionar
+        uma instância de item ao inventário do jogador e removê-la do local.
+        """
+        query = "SELECT public.sp_adicionar_item_ao_inventario(%s, %s);"
+        result = self._execute_query(query, (id_jogador, id_instancia_item), fetch_one=True)
+        # A stored procedure retorna TRUE ou FALSE, entao verificamos o valor booleano
+        return result and result['sp_adicionar_item_ao_inventario']
+    
+
+    def get_inventario_do_jogador(self, id_jogador: int):
+        """
+        Chama a stored procedure sp_ver_inventario para obter todos os itens
+        no inventário de um jogador.
+        """
+        query = "SELECT * FROM public.sp_ver_inventario(%s);"
+        return self._execute_query(query, (id_jogador,), fetch_all=True)
+    
+    def trigger_lua_de_sangue(self):
+        """
+        Chama a stored procedure lua_de_sangue para realizar o respawn
+        de monstros e itens no jogo.
+        """
+        print("\nUma energia estranha paira no ar... A Lua de Sangue esta subindo!")
+        query = "SELECT public.lua_de_sangue();"
+        self._execute_query(query)
+        print("A Lua de Sangue passou. Novos perigos aguardam!")
+
 
 # --- Bloco de Teste para o Modelo Básico ---
 if __name__ == "__main__":

--- a/app/database.py
+++ b/app/database.py
@@ -382,6 +382,28 @@ class DataBase:
         self._execute_query(query)
         print("A Lua de Sangue passou. Novos perigos aguardam!")
 
+    
+    def get_monsters_in_location(self, local_id: int):
+        """
+        Chama a stored procedure sp_encontrar_monstros_no_local para buscar e retornar
+        todos os monstros presentes em um local específico.
+        """
+        query = "SELECT * FROM public.sp_encontrar_monstros_no_local(%s);"
+        return self._execute_query(query, (local_id,), fetch_all=True)
+    
+    def kill_monsters_in_location(self, local_id: int):
+        """
+        Chama a stored procedure sp_matar_monstros_no_local para "matar"
+        todos os monstros presentes em um local específico.
+        """
+        query = "SELECT public.sp_matar_monstros_no_local(%s);"
+        result = self._execute_query(query, (local_id,), fetch_one=True)
+        # A stored procedure retorna o número de monstros mortos (ou -1 em caso de erro)
+        if result and result['sp_matar_monstros_no_local'] is not None:
+            return result['sp_matar_monstros_no_local']
+        return -1 # Indica erro se nada for retornado ou se a procedure indicar erro
+
+
 
 # --- Bloco de Teste para o Modelo Básico ---
 if __name__ == "__main__":

--- a/app/game.py
+++ b/app/game.py
@@ -302,6 +302,37 @@ class Game:
                     print("Voce nao encontrou nada de interessante aqui.")
                 input("\nPressione Enter para continuar...")
                 continue # Voltar ao inicio do loop gameplay
+
+            elif escolha == 'procurar_monstros': # <--- NOVA OPÇÃO PARA PROCURAR MONSTROS
+                print("\nVoce se prepara para procurar por sinais de vida... nao-humana.")
+                monstros_no_local = self.db.get_monsters_in_location(self.player.id_local)
+
+                if monstros_no_local:
+                    print("\nVoce avista os seguintes seres horripilantes:")
+                    for i, monstro in enumerate(monstros_no_local):
+                        nome_monstro = monstro['monstro_nome'].strip()
+                        tipo_monstro = monstro['monstro_tipo'].strip()
+                        vida_atual = monstro['vida_atual']
+                        vida_total = monstro['vida_total']
+                        print(f"  [{i + 1}] {nome_monstro} (Tipo: {tipo_monstro}, Vida: {vida_atual}/{vida_total})")
+                        # Futuramente, aqui voce poderia adicionar a logica para interagir com o monstro (ex: atacar)
+                else:
+                    print("O local parece estar livre de ameacas... por enquanto.")
+                input("\nPressione Enter para continuar...")
+                continue
+
+            elif escolha == 'kill': # <--- NOVA OPÇÃO PARA MATAR MONSTROS
+                print("\nVoce decide usar forca letal para limpar o local de qualquer ameaca...")
+                monstros_mortos_count = self.db.kill_monsters_in_location(self.player.id_local)
+                if monstros_mortos_count > 0:
+                    print(f"Voce aniquilou {monstros_mortos_count} monstros neste local!")
+                elif monstros_mortos_count == 0:
+                    print("Nao havia monstros para matar neste local.")
+                else:
+                    print("Ocorreu um erro ao tentar matar os monstros.")
+                input("\nPressione Enter para continuar...")
+                continue
+
             
             # 4. Processa o movimento
             try:

--- a/app/game.py
+++ b/app/game.py
@@ -243,7 +243,7 @@ class Game:
                 print(f"  [{i + 1}] Ir para {saida['direcao']} ({saida['tipo_destino']}): {saida['desc_saida']}")
 
             # 3. Pede a acao do jogador
-            print("\nO que voce deseja fazer? ('ficha', 'inventario', vasculhar, 'sair')")
+            print("\nO que voce deseja fazer? ('ficha', 'inventario', vasculhar, procurar_monstros, 'sair')")
             escolha = input("> ").strip().lower()
 
             if escolha == 'sair':
@@ -255,7 +255,6 @@ class Game:
                 continue
             elif escolha == 'inventario':
                 print("\n--- Seu Inventário ---")
-                # AGORA CHAMAMOS A STORED PROCEDURE PARA VER O INVENTÁRIO
                 itens_inventario = self.db.get_inventario_do_jogador(self.player.id_jogador) 
                 
                 if itens_inventario:
@@ -287,7 +286,6 @@ class Game:
                         idx_item = int(escolha_item) - 1
                         if 0 <= idx_item < len(itens_no_local):
                             item_escolhido = itens_no_local[idx_item]
-                            # Agora chamamos o método do DB que usa a stored procedure
                             if self.db.add_item_to_inventory(self.player.id_jogador, item_escolhido['instancia_item_id']):
                                 print(f"Voce pegou '{item_escolhido['item_nome'].strip()}'.")
                             else:
@@ -303,7 +301,7 @@ class Game:
                 input("\nPressione Enter para continuar...")
                 continue # Voltar ao inicio do loop gameplay
 
-            elif escolha == 'procurar_monstros': # <--- NOVA OPÇÃO PARA PROCURAR MONSTROS
+            elif escolha == 'procurar_monstros':
                 print("\nVoce se prepara para procurar por sinais de vida... nao-humana.")
                 monstros_no_local = self.db.get_monsters_in_location(self.player.id_local)
 
@@ -315,13 +313,12 @@ class Game:
                         vida_atual = monstro['vida_atual']
                         vida_total = monstro['vida_total']
                         print(f"  [{i + 1}] {nome_monstro} (Tipo: {tipo_monstro}, Vida: {vida_atual}/{vida_total})")
-                        # Futuramente, aqui voce poderia adicionar a logica para interagir com o monstro (ex: atacar)
                 else:
                     print("O local parece estar livre de ameacas... por enquanto.")
                 input("\nPressione Enter para continuar...")
                 continue
 
-            elif escolha == 'kill': # <--- NOVA OPÇÃO PARA MATAR MONSTROS
+            elif escolha == 'kill':
                 print("\nVoce decide usar forca letal para limpar o local de qualquer ameaca...")
                 monstros_mortos_count = self.db.kill_monsters_in_location(self.player.id_local)
                 if monstros_mortos_count > 0:

--- a/docs/entregas/segunda/ddl.sql
+++ b/docs/entregas/segunda/ddl.sql
@@ -110,6 +110,12 @@ Descrição: Refatoração completa do modelo de herança de itens e correção 
 - Adição do valor 'magico' ao domínio 'tipo_item' para suportar itens mágicos.
 - Remoção da chave estrangeira incorreta da tabela 'magicos' que apontava para 'tipos_feitico'.
 Autores: João Marcos, Luiz Guilherme
+
+Versão 1.6
+Data: 05/07/2025
+Descrição: Adições nas tabelas para permitir o respawn de itens e monstros
+Autores: Luiz Guilherme
+
 */
 
 DROP SCHEMA public CASCADE;
@@ -1260,7 +1266,8 @@ CREATE TABLE public.monstros(
 CREATE TABLE public.agressivos(
     id public.id_monstro_agressivo NOT NULL PRIMARY KEY, -- Usa o ID específico de agressivo
     defesa SMALLINT,
-    vida SMALLINT NOT NULL,
+    vida SMALLINT,
+    vida_total SMALLINT NOT NULL,
     catalisador_agressividade public.gatilho_agressividade,
     poder SMALLINT,
     tipo_agressivo public.tipo_monstro_agressivo NOT NULL,
@@ -1276,7 +1283,8 @@ CREATE TABLE public.agressivos(
 CREATE TABLE public.pacificos(
     id public.id_monstro_pacifico NOT NULL PRIMARY KEY, 
     defesa SMALLINT NOT NULL,
-    vida SMALLINT NOT NULL,
+    vida SMALLINT,
+    vida_total SMALLINT NOT NULL,
     motivo_passividade public.comportamento_pacifico,
     tipo_pacifico public.tipo_monstro_pacifico NOT NULL,
     conhecimento_geografico CHARACTER(128),
@@ -1291,7 +1299,8 @@ CREATE TABLE public.instancias_monstros(
 
     -- FOREING KEYS
     id_instancia_de_item public.id_instancia_de_item NOT NULL,
-    id_local public.id_local,  
+    id_local public.id_local, -- id_local = NULL indica que o monstro está morto
+    id_local_de_spawn public.id_local,  
     id_monstro public.id_monstro NOT NULL
 );
 
@@ -1389,10 +1398,12 @@ CREATE TABLE public.itens(
 
 CREATE TABLE public.instancias_de_itens(
     id public.id_instancia_de_item NOT NULL PRIMARY KEY DEFAULT public.gerar_id_instancia_de_item(),
-    durabilidade SMALLINT NOT NULL,
+    durabilidade SMALLINT, -- duarabilidade = NULL, item quebra
+    durabilidade_total SMALLINT NOT NULL,
 
     -- FOREIGN KEYS
-    id_local public.id_local,
+    id_local public.id_local, -- Se o item foi coletado, seu local é null
+    id_local_de_spawn public.id_local NOT NULL,
     id_missao_requer public.id_missao,
     id_missao_recompensa public.id_missao,
     id_item public.id_item NOT NULL

--- a/docs/entregas/segunda/ddl.sql
+++ b/docs/entregas/segunda/ddl.sql
@@ -1296,6 +1296,7 @@ CREATE TABLE public.pacificos(
 
 CREATE TABLE public.instancias_monstros(
     id public.id_instancia_de_monstro NOT NULL PRIMARY KEY DEFAULT public.gerar_id_instancia_de_monstro(),
+    vida SMALLINT,
 
     -- FOREING KEYS
     id_instancia_de_item public.id_instancia_de_item NOT NULL,

--- a/docs/entregas/segunda/dml.sql
+++ b/docs/entregas/segunda/dml.sql
@@ -545,8 +545,8 @@ SELECT public.sp_criar_arma(
 INSERT INTO public.instancias_de_itens (durabilidade, durabilidade_total, id_item, id_local, id_local_de_spawn)
 VALUES 
   (80, 80, (SELECT id FROM public.itens WHERE nome = 'Adaga Simples'), 
-  (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'),
-  (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'));
+  (SELECT id FROM public.local WHERE descricao LIKE 'O ar pesa%'),
+  (SELECT id FROM public.local WHERE descricao LIKE 'O ar pesa%'));
 
 -- Inserindo a instância do monstro com a instância do item
 INSERT INTO public.instancias_monstros (id_monstro, id_local, id_local_de_spawn, id_instancia_de_item)

--- a/docs/entregas/segunda/dml.sql
+++ b/docs/entregas/segunda/dml.sql
@@ -94,6 +94,11 @@ Data 05/07/2025
 Descrição: Adicionando itens com o procedure sp_criar_arma
 Autor: Luiz Guilherme
 
+Versão 1.8 
+Data 05/07/2025
+Descrição: Melhorias na inserção de instâncias de monstros e itens para permitir seu respawn
+Autor: Luiz Guilherme
+
 */
 -- ===============================================
 
@@ -501,6 +506,7 @@ SELECT public.sp_criar_monstro(
     p_tipo                  := 'agressivo'::public.tipo_monstro,
     p_agressivo_defesa      := 10::SMALLINT,
     p_agressivo_vida        := 50::SMALLINT,
+    p_agressivo_vida_total  := 50::SMALLINT,
     p_agressivo_catalisador := 'proximidade'::public.gatilho_agressividade,
     p_agressivo_poder       := 15::SMALLINT,
     p_agressivo_tipo        := 'psiquico'::public.tipo_monstro_agressivo,
@@ -516,6 +522,7 @@ SELECT public.sp_criar_monstro(
     p_tipo                       := 'pacífico'::public.tipo_monstro,
     p_pacifico_defesa            := 5::SMALLINT,
     p_pacifico_vida              := 30::SMALLINT,
+    p_pacifico_vida_total        := 30::SMALLINT,
     p_pacifico_motivo            := 'indiferente'::public.comportamento_pacifico,
     p_pacifico_tipo              := 'sobrenatural'::public.tipo_monstro_pacifico,
     p_pacifico_conhecimento_proibido := 'Sabe sobre a fraqueza de uma entidade maior.'::CHARACTER(128)
@@ -535,13 +542,17 @@ SELECT public.sp_criar_arma(
     p_dano                  := 4::public.dano
 );
 
-INSERT INTO public.instancias_de_itens (durabilidade, id_item, id_local)
-VALUES (80, (SELECT id FROM public.itens WHERE nome = 'Adaga Simples'), (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'));
+INSERT INTO public.instancias_de_itens (durabilidade, durabilidade_total, id_item, id_local, id_local_de_spawn)
+VALUES 
+  (80, 80, (SELECT id FROM public.itens WHERE nome = 'Adaga Simples'), 
+  (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'),
+  (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'));
 
 -- Inserindo a instância do monstro com a instância do item
-INSERT INTO public.instancias_monstros (id_monstro, id_local, id_instancia_de_item)
+INSERT INTO public.instancias_monstros (id_monstro, id_local, id_local_de_spawn, id_instancia_de_item)
 SELECT
     (SELECT id FROM public.monstros WHERE nome = 'Abominável Horror'),
+    (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'),
     (SELECT id FROM public.local WHERE descricao LIKE 'Um salão circular%'),
     (SELECT id FROM public.instancias_de_itens WHERE id_item = (SELECT id FROM public.itens WHERE nome = 'Adaga Simples'));
 


### PR DESCRIPTION
## 📝 Descrição

Adição da funcionalidade de respawn de monstros e itens. 

## 🔍 Alterações Realizadas

Criação dos procedures:
* lua_de_sangue: para respawn de monstros e itens que foram mortos ou quebraram
* sp_vasculhar_local: para consultar todos os itens que estão presentes no mesmo local que o jogador
* sp_adicionar_item_ao_inventario: para adicionar um item de uma sala no inventário do jogador
* sp_ver_inventario: para listar todos os itens do inventário do jogador
* sp_encontrar_monstros_no_local: semelhante a procura de itens só que para monstros
* sp_matar_monstros_no_local: mata todos os monstros de um local de forma automatica (para testes no jogo)

## ✅ Checklist

- [x] O código foi testado localmente
- [x] As alterações estão de acordo com o padrão de codificação do projeto
- [x] Não quebrei nenhuma funcionalidade existente

## 🧪 Como Testar

1. Rodar o ddl
2. Rodar o arquivo de triggers
3. Rodar o dml
4. Rodar o arquivo game
